### PR TITLE
fix: pin eslint to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "commitlint-config-cz": "^0.12.0",
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
-    "eslint": "^6.1.0",
+    "eslint": "6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-standard": "^13.0.1",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
<!---
  Please read the contribution guide before sending your first commit:
   https://github.com/sharvit/mongoose-data-seed/blob/master/contributing.md
-->

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] Other… Please describe: fix eslint

## Description

<!---
  Describe your changes in detail
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

since version 6.2.0 eslint giving false errors about unused-vars:
https://github.com/eslint/eslint/issues/12117

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No
