### PR TITLE
ci(greenkeeper): disable on testing and examples

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -2,17 +2,6 @@
   "groups": {
     "main": {
       "packages": ["package.json"]
-    },
-    "examples": {
-      "packages": ["examples/md-seed-example/package.json"],
-      "ignore": ["mongoose", "babel"]
-    },
-    "testing": {
-      "packages": [
-        "src/e2e/generate-sandboxes/sandbox-1/package.json",
-        "src/e2e/generate-sandboxes/sandbox-2/package.json",
-        "src/e2e/run-sandboxes/sandbox-1/package.json"
-      ]
     }
   }
 }


### PR DESCRIPTION
Disabling greenkeeper for examples and testing package.json files

fix #59

<!---
  Please read the contribution guide before sending your first commit:
   https://github.com/sharvit/mongoose-data-seed/blob/master/contributing.md
-->

## PR Type

<!---
  What types of changes does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## How Has This Been Tested?

<!---
  Please describe in detail how you tested your changes.
  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->

## Screenshots (if appropriate):

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No
